### PR TITLE
都道府県プルダウン追加

### DIFF
--- a/app/assets/stylesheets/user.scss
+++ b/app/assets/stylesheets/user.scss
@@ -65,6 +65,10 @@
             width: 350px;
             height: 35px;
           }
+          select {
+            margin: 0;
+            height: 35px;
+          }
         }
 
         .formfield__label--normal {

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,0 +1,23 @@
+class Prefecture < ActiveHash::Base
+  self.data = [
+      {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, {id: 3, name: '岩手県'},
+      {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, {id: 6, name: '山形県'},
+      {id: 7, name: '福島県'}, {id: 8, name: '茨城県'}, {id: 9, name: '栃木県'},
+      {id: 10, name: '群馬県'}, {id: 11, name: '埼玉県'}, {id: 12, name: '千葉県'},
+      {id: 13, name: '東京都'}, {id: 14, name: '神奈川県'}, {id: 15, name: '新潟県'},
+      {id: 16, name: '富山県'}, {id: 17, name: '石川県'}, {id: 18, name: '福井県'},
+      {id: 19, name: '山梨県'}, {id: 20, name: '長野県'}, {id: 21, name: '岐阜県'},
+      {id: 22, name: '静岡県'}, {id: 23, name: '愛知県'}, {id: 24, name: '三重県'},
+      {id: 25, name: '滋賀県'}, {id: 26, name: '京都府'}, {id: 27, name: '大阪府'},
+      {id: 28, name: '兵庫県'}, {id: 29, name: '奈良県'}, {id: 30, name: '和歌山県'},
+      {id: 31, name: '鳥取県'}, {id: 32, name: '島根県'}, {id: 33, name: '岡山県'},
+      {id: 34, name: '広島県'}, {id: 35, name: '山口県'}, {id: 36, name: '徳島県'},
+      {id: 37, name: '香川県'}, {id: 38, name: '愛媛県'}, {id: 39, name: '高知県'},
+      {id: 40, name: '福岡県'}, {id: 41, name: '佐賀県'}, {id: 42, name: '長崎県'},
+      {id: 43, name: '熊本県'}, {id: 44, name: '大分県'}, {id: 45, name: '宮崎県'},
+      {id: 46, name: '鹿児島県'}, {id: 47, name: '沖縄県'}
+  ]
+
+  include ActiveHash::Associations
+  has_many :sending_destination
+end

--- a/app/models/sending_destination.rb
+++ b/app/models/sending_destination.rb
@@ -2,4 +2,6 @@ class SendingDestination < ApplicationRecord
   belongs_to :user, optional: true
   validates :destination_first_name, :destination_family_name, :destination_first_name_kana, :destination_family_name_kana, :post_code, :prefecture_code, :city, :house_number, presence: true
   validates :post_code, format: { with: /\A\d{3}[-]\d{4}$|^\d{3}[-]\d{2}$|^\d{3}\z/ }
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :prefecture
 end

--- a/app/views/devise/registrations/new_sending_destination.html.haml
+++ b/app/views/devise/registrations/new_sending_destination.html.haml
@@ -44,57 +44,7 @@
           .formfield__label--normal
             = f.label :prefecture_code, '都道府県 ※必須'
           .formfield__input--normal
-            = f.text_field :prefecture_code, autofocus: true, autocomplete: "prefecture_code", placeholder:"例：東京都"
-            %select.sell__main__content__form__box__group__select__category
-                %option ---
-                %option{value: 1} 北海道
-                %option{value: 2} 青森県
-                %option{value: 3} 岩手県
-                %option{value: 4} 宮城県
-                %option{value: 5} 秋田県
-                %option{value: 6} 山形県
-                %option{value: 7} 福島県
-                %option{value: 8} 茨城県
-                %option{value: 9} 栃木県
-                %option{value: 10} 群馬県
-                %option{value: 11} 埼玉県
-                %option{value: 12} 千葉県
-                %option{value: 13} 東京都
-                %option{value: 14} 神奈川県
-                %option{value: 15} 新潟県
-                %option{value: 16} 富山県
-                %option{value: 17} 石川県
-                %option{value: 18} 福井県
-                %option{value: 19} 山梨県
-                %option{value: 20} 長野県
-                %option{value: 21} 岐阜県
-                %option{value: 22} 静岡県
-                %option{value: 23} 愛知県
-                %option{value: 24} 三重県
-                %option{value: 25} 滋賀県
-                %option{value: 26} 京都府
-                %option{value: 27} 大阪府
-                %option{value: 28} 兵庫県
-                %option{value: 29} 奈良県
-                %option{value: 30} 和歌山県
-                %option{value: 31} 鳥取県
-                %option{value: 32} 島根県
-                %option{value: 33} 岡山県
-                %option{value: 34} 広島県
-                %option{value: 35} 山口県
-                %option{value: 36} 徳島県
-                %option{value: 37} 香川県
-                %option{value: 38} 愛媛県
-                %option{value: 39} 高知県
-                %option{value: 40} 福岡県
-                %option{value: 41} 佐賀県
-                %option{value: 42} 長崎県
-                %option{value: 43} 熊本県
-                %option{value: 44} 大分県
-                %option{value: 45} 宮崎県
-                %option{value: 46} 鹿児島県
-                %option{value: 47} 沖縄県
-                %option{value: 99} 未定
+            = f.collection_select :prefecture_code, Prefecture.all, :id, :name,{include_blank: "---"}
         .loginregist__form__field
           .formfield__label--normal
             = f.label :city, '市区町村 ※必須'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2020_08_10_124342) do
 
   create_table "credit_cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -31,7 +30,7 @@ ActiveRecord::Schema.define(version: 2020_08_10_124342) do
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", null: false
+    t.string "name", limit: 255, null: false
     t.integer "price", null: false
     t.string "trading_status", limit: 255, null: false
     t.timestamp "deal_closed_date"
@@ -40,13 +39,13 @@ ActiveRecord::Schema.define(version: 2020_08_10_124342) do
   end
 
   create_table "profiles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "first_name", null: false
-    t.string "family_name", null: false
-    t.string "first_name_kana", null: false
-    t.string "family_name_kana", null: false
-    t.string "birth_day", null: false
+    t.string "first_name", limit: 255, null: false
+    t.string "family_name", limit: 255, null: false
+    t.string "first_name_kana", limit: 255, null: false
+    t.string "family_name_kana", limit: 255, null: false
+    t.string "birth_day", limit: 255, null: false
     t.text "introduction", null: false
-    t.string "avatar"
+    t.string "avatar", limit: 255
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -54,14 +53,14 @@ ActiveRecord::Schema.define(version: 2020_08_10_124342) do
   end
 
   create_table "sending_destinations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "destination_first_name", null: false
-    t.string "destination_family_name", null: false
-    t.string "destination_first_name_kana", null: false
-    t.string "destination_family_name_kana", null: false
+    t.string "destination_first_name", limit: 255, null: false
+    t.string "destination_family_name", limit: 255, null: false
+    t.string "destination_first_name_kana", limit: 255, null: false
+    t.string "destination_family_name_kana", limit: 255, null: false
     t.integer "post_code", null: false
     t.integer "prefecture_code", null: false
-    t.string "city", null: false
-    t.string "house_number", null: false
+    t.string "city", limit: 255, null: false
+    t.string "house_number", limit: 255, null: false
     t.integer "phone_number"
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -70,14 +69,14 @@ ActiveRecord::Schema.define(version: 2020_08_10_124342) do
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
+    t.string "email", limit: 255, default: "", null: false
+    t.string "encrypted_password", limit: 255, default: "", null: false
+    t.string "reset_password_token", limit: 255
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "nickname", default: "", null: false
+    t.string "nickname", limit: 255, default: "", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
#What
新規登録の送付先住所の都道府県入力欄をプルダウン式に変更した。

#Why
プルダウン式の方がわかりやすく簡単に入力できるため。