### PR TITLE
header微調整

### DIFF
--- a/app/views/items/_header.html.haml
+++ b/app/views/items/_header.html.haml
@@ -52,7 +52,7 @@
           - if user_signed_in?
             %li.listsRight-login
               = link_to "ログアウト", destroy_user_session_path, method: :delete
-            %li.listsRight-mypage
+            %li.listsRight-new
               = link_to "マイページ", user_path(current_user)
           - else
             %li.listsRight-login


### PR DESCRIPTION
#What
ヘッダーのビュー(ログイン、マイページ リンク)のズレを調整した。

#Why
ビュー崩れを直し正しい見た目にするため。